### PR TITLE
Escape HTML usernames

### DIFF
--- a/_includes/user_handling.html
+++ b/_includes/user_handling.html
@@ -6,7 +6,14 @@
     if (!user || !user.id || !user.username) return;
     $('.user-sign-in-link').addClass('hidden');
     $('.user-sign-out-link').addClass('shown');
-    $('.user-profile-text').html(user.username);
+    $('.user-profile-text').html(
+      user.username
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#039;')
+    );
     $('.user-profile-link').addClass('shown');
     $('.user-profile-dropdown').addClass('shown');
   });


### PR DESCRIPTION
## Description
Escapes usernames.

## Motivation and Context
Usernames with HTML code in them could do anything from messing with the page layout to running JS code.

Escaping user-controllable fields is good practise regardless. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Windows (Firefox, Edge)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
