### PR TITLE
Fix the navbar on mobile

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -3,9 +3,7 @@
     <div class="navbar-header">
       <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false" aria-controls="navbar">
         <span class="sr-only">Toggle navigation</span>
-        <span class="icon-bar"></span>
-        <span class="icon-bar"></span>
-        <span class="icon-bar"></span>
+        <span class="fas fa-bars"></span>
       </button>
       <a class="navbar-brand" href="{{ site.data.routes.home }}">{{ site.title }}</a>
     </div>

--- a/_includes/nav_with_settings.html
+++ b/_includes/nav_with_settings.html
@@ -3,9 +3,7 @@
     <div class="navbar-header">
       <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false" aria-controls="navbar">
         <span class="sr-only">Toggle navigation</span>
-        <span class="icon-bar"></span>
-        <span class="icon-bar"></span>
-        <span class="icon-bar"></span>
+        <span class="fas fa-bars"></span>
       </button>
       <button type="button" class="settings-toggle-mobile collapsed" data-toggle="collapse" data-target=".settings" aria-expanded="false" aria-controls="settings">
         <span class="sr-only">Toggle settings</span>

--- a/assets/css/navbar.scss
+++ b/assets/css/navbar.scss
@@ -107,3 +107,53 @@ $navbar-height-large: 60px;
     display: block !important;
   }
 }
+
+.navbar-header button {
+  width: 32px;
+  height: 32px;
+  margin-top: 10px;
+  margin-bottom: 10px;
+  padding: 6px;
+  background-color: transparent;
+  background-image: none;
+  border: 1px solid #333;
+  border-radius: 4px;
+  color: #fff;
+}
+
+@media (min-width: 325px) {
+  .navbar-header button {
+    width: 44px;
+    height: 36px;
+    margin-top: 8px;
+    margin-bottom: 8px;
+    padding: 8px;
+    font-size: 16px;
+  }
+}
+
+.navbar .container {
+  width: 100%;
+}
+
+.nav > li > a {
+  padding-left: 10px;
+  padding-right: 10px;
+}
+
+@media (min-width: 992px) {
+  .navbar .container {
+    width: 940px;
+  }
+
+  .nav > li > a {
+    padding-left: 15px;
+    padding-right: 15px;
+  }
+}
+
+@media (min-width: 1200px) {
+  .navbar .container {
+    width: 1140px;
+  }
+}

--- a/assets/css/settings.scss
+++ b/assets/css/settings.scss
@@ -2,6 +2,7 @@
   line-height: calc(#{$navbar-height-large} - 32px) !important;
   margin-top: 10px;
   margin-bottom: 10px;
+  margin-right: 15px;
   padding-top: 5px !important;
   padding-bottom: 5px !important;
   border: 1px solid #333;
@@ -18,16 +19,12 @@
 }
 
 .settings-toggle-mobile {
-  position: relative;
   float: right;
-  padding: 9px 10px;
-  margin-top: 8px;
-  margin-right: 15px;
-  margin-bottom: 8px;
   background-color: transparent;
   background-image: none;
   border: 1px solid #333;
   border-radius: 4px;
+  margin-right: 8px;
 }
 
 .settings-toggle-mobile:focus {
@@ -37,14 +34,6 @@
 .settings-toggle-mobile:hover,
 .settings-toggle-mobile:focus {
   background-color: #333;
-}
-
-.settings-toggle-mobile .fa-cog {
-  display: block;
-  width: 22px;
-  height: 14px !important;
-  border-radius: 1px !important;
-  color: #fff !important;
 }
 
 @media (max-width: 767px) {


### PR DESCRIPTION
## Description
Adds a new navbar breakpoint at 325px, where the settings/menu buttons increase in size.

## Motivation and Context
This fixes an issue on some mobile devices where the navbar breaks onto two lines, obscuring parts of the screen.

## How Has This Been Tested?
Windows (Firefox)
Android (Firefox)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
